### PR TITLE
Fix RandomSpawn nether issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle properties
 group = net.civmc.randomspawn
-version = 3.0.2
+version = 3.0.3-SNAPSHOT
 description = RandomSpawn
 
 # Custom Properties

--- a/paper/src/main/java/me/josvth/randomspawn/RandomSpawn.java
+++ b/paper/src/main/java/me/josvth/randomspawn/RandomSpawn.java
@@ -32,7 +32,6 @@ public class RandomSpawn extends JavaPlugin {
 	WorldChangeListener worldChangeListener;
 	SignListener signListener;
 	DamageListener damageListener;
-	private boolean isBastionsEnabled = false;
 
 	private static List<Material> defaultBlackList = Arrays.asList(
 			new Material[] { Material.WATER, Material.LAVA, Material.FIRE, Material.CACTUS, Material.MAGMA_BLOCK });
@@ -53,9 +52,6 @@ public class RandomSpawn extends JavaPlugin {
 		worldChangeListener = new WorldChangeListener(this);
 		signListener = new SignListener(this);
 		damageListener = new DamageListener(this);
-
-		isBastionsEnabled = getServer().getPluginManager().isPluginEnabled("Bastion");
-
 	}
 
 	public void logInfo(String message) {
@@ -125,11 +121,11 @@ public class RandomSpawn extends JavaPlugin {
 			return null;
 		}
 
-		if (isBastionsEnabled) {
+		if (getServer().getPluginManager().isPluginEnabled("Bastion")) {
 			BastionBlockManager bm = Bastion.getBastionManager();
 			if (bm != null) {
 				if (!bm.getBlockingBastions(ret).isEmpty()) {
-					return chooseSpawn(world);
+					return chooseSpawn(world); // TODO: infinite recursion seems rather dangerous
 				}
 			}
 		}

--- a/paper/src/main/java/me/josvth/randomspawn/RandomSpawn.java
+++ b/paper/src/main/java/me/josvth/randomspawn/RandomSpawn.java
@@ -228,10 +228,17 @@ public class RandomSpawn extends JavaPlugin {
 
 		// Search the Nether for a valid Y from the bottom-up.
 		if (world.getEnvironment() == Environment.NETHER) {
-			floorBlock = world.getBlockAt((int) x, world.getMinHeight(), (int) z);
+			// TODO: These are here due to an odd behaviour with vanilla nether. The roof-bedrock
+			//       will be at y128, but the world-height is 256. Using the max-height API would
+			//       mean that players occasionally get spawned above the roof. The empty blocks
+			//       above the roof are AIR, not VOID_AIR, so you cannot check for that either.
+			final int netherMinHeight = 0; // world.getMinHeight();
+			final int netherMaxHeight = 128; // world.getMaxHeight();
+
+			floorBlock = world.getBlockAt((int) x, netherMinHeight, (int) z);
 			feetBlock = floorBlock.getRelative(0, 1, 0);
 			headBlock = floorBlock.getRelative(0, 2, 0);
-			while (headBlock.getY() < world.getMaxHeight()) {
+			while (headBlock.getY() < netherMaxHeight) {
 				if (isValidSpawnLocation(headBlock, feetBlock, floorBlock, blacklist)) {
 					return (double) feetBlock.getY();
 				}
@@ -244,10 +251,16 @@ public class RandomSpawn extends JavaPlugin {
 
 		// Otherwise do a top-down search.
 		else {
+			// TODO: This is here to prevent players from rare instances of being spawned deep
+			//       underground. Lava lakes typically only generate at around y30, so players
+			//       unfortunate enough to be spawned underground should have relative safety.
+			//       Keep in mind that this else also applies to other dimensions like the End.
+			final int otherMinHeight = 40; // world.getMinHeight();
+
 			headBlock = world.getBlockAt((int) x, world.getMaxHeight(), (int) z);
 			feetBlock = headBlock.getRelative(0, -1, 0);
 			floorBlock = headBlock.getRelative(0, -2, 0);
-			while (floorBlock.getY() >= world.getMinHeight()) {
+			while (floorBlock.getY() >= otherMinHeight) {
 				if (isValidSpawnLocation(headBlock, feetBlock, floorBlock, blacklist)) {
 					return (double) feetBlock.getY();
 				}

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${version}
 main: me.josvth.randomspawn.RandomSpawn
 author: Josvth
 softdepend: [Bastion]
-api-version: 1.17
+api-version: 1.18
 commands:
   randomspawn:
     description: The main command.

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: ${name}
 version: ${version}
 main: me.josvth.randomspawn.RandomSpawn
 author: Josvth
+depend: [BanStick]
 softdepend: [Bastion]
 api-version: 1.18
 commands:


### PR DESCRIPTION
This PR fixes the obnoxious respawning behaviour in the Nether of constantly finding yourself in lava lakes or above the roof-bedrock. RedDevel and I did a 10-respawn test where I was pearled and killed 10 times to force a respawn. All 10 respawns were in perfectly valid locations.